### PR TITLE
Corrected dpi settings in pdftoppm to improve OCR results and in hocr2pdf to improve layout of text in final pdf

### DIFF
--- a/pdfocr.rb
+++ b/pdfocr.rb
@@ -305,7 +305,7 @@ Dir.chdir(tmp+"/") {
 	end
 	puts "Converting page #{i} to ppm"
 
-	sh "pdftoppm #{shell_escape(basefn)}.pdf >#{shell_escape(basefn)}.ppm"
+	sh "pdftoppm -r 300 #{shell_escape(basefn)}.pdf >#{shell_escape(basefn)}.ppm"
 	if not File.file?(basefn+'.ppm')
 		puts "Error while converting page #{i} to ppm"
 		next
@@ -324,7 +324,7 @@ Dir.chdir(tmp+"/") {
 		next
 	end
 	puts "Embedding text into PDF for page #{i}"
-	sh "hocr2pdf -i #{shell_escape(basefn)}.ppm -s -o #{shell_escape(basefn)}-new.pdf < #{shell_escape(basefn)}.hocr"
+	sh "hocr2pdf -r 300 -i #{shell_escape(basefn)}.ppm -s -o #{shell_escape(basefn)}-new.pdf < #{shell_escape(basefn)}.hocr"
 	if not File.file?(basefn+'-new.pdf')
 		puts "Error while embedding text into PDF for page #{i}"
 		next


### PR DESCRIPTION
set xy resolution of images to 300dpi
(by default pdftoppm generates images with 150dpi resolution, which leads to poor OCR recognition)
set also resolution to 300dpi when converting image to PDF using hocr2pdf
(This ensures that layout of the text is compatible to the image dpi)
