### PR TITLE
bypassing hocr2pdf that can't handle the new hocr format

### DIFF
--- a/pdfocr.rb
+++ b/pdfocr.rb
@@ -333,19 +333,12 @@ Dir.chdir(tmp+"/") {
   if usecuneiform
     sh "cuneiform", "-l", language, "-f", "hocr", "-o", basefn+'.hocr', basefn+'.ppm'
   elsif usetesseract
-    sh "tesseract", "-l", language, basefn+'.ppm', basefn+'.hocr', "hocr"
-    sh "mv", basefn+'.hocr.html', basefn+'.hocr'
+    sh "tesseract", "-l", language, basefn+'.ppm', basefn+'-new', "pdf"
   else
     sh "ocroscript recognize #{shell_escape(basefn)}.ppm > #{shell_escape(basefn)}.hocr"
   end
-  if not File.file?(basefn+'.hocr')
-    puts "Error while running OCR on page #{i}"
-    next
-  end
-  puts "Embedding text into PDF for page #{i}"
-  sh "hocr2pdf -r 300 -i #{shell_escape(basefn)}.ppm -s -o #{shell_escape(basefn)}-new.pdf < #{shell_escape(basefn)}.hocr"
   if not File.file?(basefn+'-new.pdf')
-    puts "Error while embedding text into PDF for page #{i}"
+    puts "Error while running OCR on page #{i}"
     next
   end
 }


### PR DESCRIPTION
tested versions:
hocr2pdf v0.8.9
tesseract v3.03
pdfocr v0.1.4

symptom:
An output pdf of hocr2pdf does not contain all the texts from an output of tesseract. When I open an output file of hocr2pdf in a pdf viewer and try to find a word, the locations of found words are displayed in a wrong position and many words are not searchable at all. It looks like font sizes overlapped text or locations of the texts are wrong. It seems this is a bug of hocr2pdf that cannot handle word by word format of hocr.

https://bugs.launchpad.net/cuneiform-linux/+bug/623438

hocr2pdf seems that it can only handle a hocr file that specifies a location of each character. It seems it cannot handle a new format of hocr file that specifies a location of each word. However tesseract generates a hocr file that specifies locations of words, not characters.

fix:
Below code bypasses this bug and enables pdfocr to do the job without hocr2pdf by using tesseract's feature to make a sandwich pdf.
