### PR TITLE
add -L parameter to allow language combinations bypass the language avai...

### DIFF
--- a/pdfocr.rb
+++ b/pdfocr.rb
@@ -107,6 +107,11 @@ eos
     language = fn
     checklang = true
   }
+
+  opts.on("-L", "--nocheck-lang LANG", "Suppress checking of language parameter") { |fn|
+    language = fn
+    checklang = false
+  }
   
   opts.on("-w", "--workingdir [DIR]", "Specify directory to store temp files in") { |fn|
     deletedir = false


### PR DESCRIPTION
add -L parameter to allow language combinations bypass the language availability check

tesseract allows to give several languages at once, e.g. "deu+eng". Unfortunately that is prevented by the language availability check in pdfocr.rb. Rather than extend that part with my limited Ruby knowledge, I added a seperate -L parameter that is simply passed on without checking. Since I only use this in scripting, I don't really need the extra safety there. What do you think?