### PR TITLE
Update pdfocr.rb

### DIFF
--- a/pdfocr.rb
+++ b/pdfocr.rb
@@ -352,10 +352,12 @@ Dir.chdir(tmp+"/") {
   else
     sh "ocroscript recognize #{shell_escape(basefn)}.ppm > #{shell_escape(basefn)}.hocr"
   end
-  if not File.file?(basefn+'-new.pdf')
-    puts "Error while running OCR on page #{i}"
-    next
-  end
+  if not usetesseract
+    if not File.file?(basefn+'-new.pdf')
+      puts "Error while running OCR on page #{i}"
+      next
+    end
+  end    
 }
 
 }

--- a/pdfocr.rb
+++ b/pdfocr.rb
@@ -339,6 +339,16 @@ Dir.chdir(tmp+"/") {
     sh "cuneiform", "-l", language, "-f", "hocr", "-o", basefn+'.hocr', basefn+'.ppm'
   elsif usetesseract
     sh "tesseract", "-l", language, basefn+'.ppm', basefn+'-new', "pdf"
+    if not File.file?(basefn+'-new.pdf')
+      puts "Error while running OCR on page #{i}"
+      sh "mv #{basefn+'.pdf'}  #{basefn+'-new.pdf'}"
+    end
+    puts "Merging ..."
+    sh "pdftk #{tmp+'/'+'*-new.pdf'} cat output #{tmp+'/merged.ocrpdf'}"
+    sh "rm -Rf #{tmp+'/'+'*-new.pdf'}"
+    sh "rm -Rf #{tmp+'/'+'*.ppm'}"
+    sh "rm -Rf #{tmp+'/'+'*.pdf'}"
+    sh "mv #{tmp+'/merged.ocrpdf'} #{tmp+'/0000000000000-merged-new.pdf'}"
   else
     sh "ocroscript recognize #{shell_escape(basefn)}.ppm > #{shell_escape(basefn)}.hocr"
   end
@@ -349,10 +359,13 @@ Dir.chdir(tmp+"/") {
 }
 
 }
-
-puts "Merging together PDF files"
-
-sh "pdftk #{tmp+'/'+'*-new.pdf'} cat output #{tmp+'/merged.pdf'}"
+if usetesseract
+        puts "renaming merged-new.pdf to merged.pdf"
+        sh "mv #{tmp+'/0000000000000-merged-new.pdf'} #{tmp+'/merged.pdf'}"
+elsif
+        puts "Merging together PDF files"
+        sh "pdftk #{tmp+'/'+'*-new.pdf'} cat output #{tmp+'/merged.pdf'}"
+end
 
 puts "Updating PDF info for #{outfile}"
 

--- a/pdfocr.rb
+++ b/pdfocr.rb
@@ -345,9 +345,9 @@ Dir.chdir(tmp+"/") {
     end
     puts "Merging ..."
     sh "pdftk #{tmp+'/'+'*-new.pdf'} cat output #{tmp+'/merged.ocrpdf'}"
-    sh "rm -Rf #{tmp+'/'+'*-new.pdf'}"
-    sh "rm -Rf #{tmp+'/'+'*.ppm'}"
-    sh "rm -Rf #{tmp+'/'+'*.pdf'}"
+    sh "rm -f #{tmp+'/'+'*-new.pdf'}"
+    sh "rm -f #{tmp+'/'+'*.ppm'}"
+    sh "rm -f #{tmp+'/'+'*.pdf'}"
     sh "mv #{tmp+'/merged.ocrpdf'} #{tmp+'/0000000000000-merged-new.pdf'}"
   else
     sh "ocroscript recognize #{shell_escape(basefn)}.ppm > #{shell_escape(basefn)}.hocr"


### PR DESCRIPTION
fixed: if running with tesseract and couldn't ocr scan one page of the source-pdf , this page was removed from the destination-pdf
fixed: if running with tesseract on large pdf's we could run into OutOfDiscSpace