### PR TITLE
Improve compatibility with ruby version managers

### DIFF
--- a/pdfocr.rb
+++ b/pdfocr.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 
 # Copyright (c) 2010 Geza Kovacs
 #


### PR DESCRIPTION
For those who use rvm and don't even have a globally installed ruby this should make it work.